### PR TITLE
feat: Add real-world examples section

### DIFF
--- a/apps/statistical-fallacy-spotter/index.html
+++ b/apps/statistical-fallacy-spotter/index.html
@@ -34,6 +34,8 @@
             <p id="modal-long-description"></p>
             <h3>Example</h3>
             <p id="modal-example"></p>
+            <h3>Real-World Examples</h3>
+            <div id="modal-real-world-examples"></div>
         </div>
     </div>
 

--- a/apps/statistical-fallacy-spotter/script.js
+++ b/apps/statistical-fallacy-spotter/script.js
@@ -5,6 +5,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const modalTitle = document.getElementById('modal-title');
     const modalLongDescription = document.getElementById('modal-long-description');
     const modalExample = document.getElementById('modal-example');
+    const modalRealWorldExamples = document.getElementById('modal-real-world-examples');
     const closeButton = document.querySelector('.close-button');
 
     let fallacies = [];
@@ -58,6 +59,20 @@ document.addEventListener('DOMContentLoaded', () => {
         modalTitle.textContent = fallacy.name;
         modalLongDescription.textContent = fallacy.long_description;
         modalExample.textContent = fallacy.example_application;
+
+        modalRealWorldExamples.innerHTML = '';
+        if (fallacy.real_world_examples && fallacy.real_world_examples.length > 0) {
+            const ul = document.createElement('ul');
+            fallacy.real_world_examples.forEach(example => {
+                const li = document.createElement('li');
+                li.textContent = example;
+                ul.appendChild(li);
+            });
+            modalRealWorldExamples.appendChild(ul);
+        } else {
+            modalRealWorldExamples.textContent = 'No real-world examples available.';
+        }
+
         modal.style.display = 'block';
     }
 

--- a/apps/statistical-fallacy-spotter/statistical-fallacies.json
+++ b/apps/statistical-fallacy-spotter/statistical-fallacies.json
@@ -4,6 +4,10 @@
     "short_description": "Selectively choosing data that supports a claim while ignoring contradictory data.",
     "long_description": "Cherry picking, also known as suppressing evidence or the fallacy of incomplete evidence, is the act of pointing to individual cases or data that seem to confirm a particular position, while ignoring a significant portion of related cases or data that may contradict that position. It is a form of selection bias. For example, a company might highlight a few successful projects while ignoring the many that failed.",
     "example_application": "A study on the safety of a new drug only reports the positive outcomes and omits the side effects.",
+    "real_world_examples": [
+      "A politician points to a single city with a low crime rate as evidence that their new crime bill is working, while ignoring rising crime rates in other cities.",
+      "A news report on climate change only interviews scientists who are skeptical of the consensus view, ignoring the vast majority of climate scientists."
+    ],
     "tags": ["selection-bias", "data-analysis", "research"]
   },
   {
@@ -11,6 +15,10 @@
     "short_description": "Focusing on successful cases while overlooking those that failed.",
     "long_description": "Survivorship bias is a logical error of concentrating on the people or things that 'survived' some process and inadvertently overlooking those that did not because of their lack of visibility. This can lead to false conclusions in several different ways. For example, in finance, looking only at the performance of existing companies and not those that have gone bankrupt will lead to an overestimation of the average performance of companies.",
     "example_application": "Studying only successful entrepreneurs to learn about the keys to success, ignoring the vast majority of entrepreneurs who failed.",
+    "real_world_examples": [
+      "News articles often feature stories of college dropouts who became billionaires, leading people to believe that dropping out of college is a good strategy for success, while ignoring the vast majority of dropouts who are not successful.",
+      "Social media is filled with posts from successful influencers, creating the impression that being an influencer is an easy and lucrative career, while the many who fail to gain traction are invisible."
+    ],
     "tags": ["selection-bias", "business", "statistics"]
   },
   {
@@ -18,6 +26,10 @@
     "short_description": "A trend that appears in different groups of data disappears or reverses when the groups are combined.",
     "long_description": "Simpson's paradox is a phenomenon in probability and statistics, in which a trend appears in several different groups of data but disappears or reverses when these groups are combined. This result is often encountered in social-science and medical-science statistics and is particularly confounding when frequency data is unduly given causal interpretations. For example, a drug might appear to be effective for both men and women when analyzed separately, but when the data is combined, it may appear to be ineffective or even harmful.",
     "example_application": "A university has a higher admission rate for men than women, but for each department, the admission rate is higher for women.",
+    "real_world_examples": [
+      "In the 1973 UC Berkeley gender bias case, the overall admission figures showed that men were more likely to be admitted than women, but when broken down by department, women had a higher admission rate in most departments. The paradox was caused by women tending to apply to more competitive departments with lower admission rates for both sexes.",
+      "A study might show that a certain treatment is more effective in two different hospitals, but when the data is combined, it appears less effective. This could be because one hospital treats more serious cases."
+    ],
     "tags": ["statistics", "data-analysis", "paradox"]
   },
   {
@@ -25,6 +37,10 @@
     "short_description": "An incentive designed to solve a problem ends up making the problem worse.",
     "long_description": "The cobra effect occurs when an attempted solution to a problem makes the problem worse, as a type of unintended consequence. The term is used to illustrate how incorrect stimulation in economics and politics can cause unintended consequences. It is named after an anecdote set in the time of British rule of colonial India. The British government, concerned about the number of venomous cobras in Delhi, offered a bounty for every dead cobra. Initially, this was a successful strategy; large numbers of snakes were killed for the reward. Eventually, however, enterprising people began to breed cobras for the income. When the government became aware of this, the reward program was scrapped, causing the cobra breeders to set the now-worthless snakes free.",
     "example_application": "Paying for bug bounties by the number of bugs found, leading to developers writing more buggy code.",
+    "real_world_examples": [
+      "In the 1990s, Mexico City implemented a policy to reduce air pollution by restricting driving one day a week based on license plate numbers. In response, many people bought a second car, often an older, more polluting one, which worsened the pollution.",
+      "A social media platform's algorithm designed to promote 'engaging' content might inadvertently amplify misinformation and conspiracy theories because they generate a lot of comments and shares."
+    ],
     "tags": ["incentives", "economics", "unintended-consequences"]
   },
   {
@@ -32,6 +48,10 @@
     "short_description": "Making a decision based solely on what is quantitatively measurable, while ignoring all other factors.",
     "long_description": "The McNamara fallacy (also known as the quantitative fallacy), named for Robert McNamara, the US Secretary of Defense from 1961 to 1968, involves making a decision based solely on quantitative observations (or metrics) and ignoring all others. The first step is to measure whatever can be easily measured. The second step is to disregard that which can't be easily measured or to give it an arbitrary quantitative value. This is artificial and misleading. The third step is to presume that what can't be measured easily really isn't important. This is blindness. The fourth step is to say that what can't be easily measured really doesn't exist. This is suicide.",
     "example_application": "Judging the success of a military campaign solely on the number of enemy casualties, ignoring factors like strategic position or public support.",
+    "real_world_examples": [
+      "A school system might be judged solely on standardized test scores, ignoring other important factors like student creativity, critical thinking, and well-being.",
+      "A company might focus solely on quarterly profits, leading to decisions that harm long-term growth and employee morale."
+    ],
     "tags": ["metrics", "decision-making", "qualitative"]
   },
   {
@@ -39,6 +59,10 @@
     "short_description": "Belief that past random events influence future independent events.",
     "long_description": "The gambler's fallacy, also known as the Monte Carlo fallacy or the fallacy of the maturity of chances, is the mistaken belief that, if something happens more frequently than normal during a given period, it will happen less frequently in the future (or vice versa). In situations where the outcome being observed is truly random and consists of independent trials of a random process, this belief is false. The fallacy can arise in many practical situations, but is most strongly associated with gambling, where it is common among players.",
     "example_application": "Believing that a coin is 'due' to land on heads after a long streak of tails.",
+    "real_world_examples": [
+      "A stock market investor might believe that a stock is 'due' for a correction after a long period of growth, even if there are no underlying reasons for it to fall.",
+      "A person might believe that they are 'due' for a win on a slot machine after a long series of losses."
+    ],
     "tags": ["probability", "randomness", "gambling"]
   },
   {
@@ -46,6 +70,10 @@
     "short_description": "The alteration of behavior by the subjects of a study due to their awareness of being observed.",
     "long_description": "The Hawthorne effect is a type of reactivity in which individuals modify an aspect of their behavior in response to their awareness of being observed. This can negatively affect the validity of research, particularly in the social sciences. For example, in a study on productivity, workers might be more productive simply because they know they are being studied, not because of any change in their working conditions.",
     "example_application": "Workers in a factory temporarily become more productive when they know they are being observed by researchers.",
+    "real_world_examples": [
+      "In a study on the effectiveness of a new teaching method, students might perform better simply because they are receiving more attention from teachers and researchers.",
+      "People in a focus group might express more positive opinions about a product because they know they are being observed by the company."
+    ],
     "tags": ["research", "psychology", "observation"]
   },
   {
@@ -53,6 +81,10 @@
     "short_description": "The tendency of extreme results to be followed by less extreme ones.",
     "long_description": "Regression toward the mean is the phenomenon that if a variable is extreme on its first measurement, it will tend to be closer to the average on its second measurement—and if it is extreme on its second measurement, it will tend to have been closer to the average on its first. It is a common statistical phenomenon that can be mistaken for a causal effect. For example, a student who scores very high on a test is likely to score lower on the next test, and a student who scores very low is likely to score higher. This is not because of any change in their ability, but because their first score was likely affected by luck.",
     "example_application": "A basketball player who has an exceptionally good game is likely to have a more average game next time.",
+    "real_world_examples": [
+      "The 'Sports Illustrated cover jinx' is a famous example, where athletes who appear on the cover of the magazine often seem to have a decline in performance afterward. This is likely due to regression to the mean, as athletes are most likely to be featured on the cover after an exceptionally good performance.",
+      "A restaurant that receives a rave review might seem to have lower quality on a subsequent visit. This could be because the first visit was exceptionally good, and the second visit is closer to the average."
+    ],
     "tags": ["statistics", "performance", "luck"]
   },
   {
@@ -60,6 +92,10 @@
     "short_description": "Ignoring randomness when it happens, but highlighting it when it seems meaningful.",
     "long_description": "The Texas sharpshooter fallacy is an informal fallacy which is committed when differences in data are ignored, but similarities are overemphasized. From this reasoning, a false conclusion is inferred. This fallacy is the philosophical/rhetorical application of the multiple comparisons problem (in statistics) and apophenia (in psychology). It is related to the clustering illusion; people have a tendency to under-predict the amount of structure that will appear in random data. The name comes from a joke about a Texan who fires some gunshots at the side of a barn, then paints a target centered on the tightest cluster of hits and claims to be a sharpshooter.",
     "example_application": "A psychic makes many vague predictions, and when one of them happens to come true, they claim to have psychic powers.",
+    "real_world_examples": [
+      "A conspiracy theorist might find a few seemingly related details in a large amount of information and use them to construct a complex theory, while ignoring all the contradictory evidence.",
+      "A health supplement company might claim that their product is effective because a few people who used it had positive results, while ignoring the many who did not."
+    ],
     "tags": ["randomness", "pattern-recognition", "coincidence"]
   },
   {
@@ -67,6 +103,10 @@
     "short_description": "Judging a combined event more likely than a single constituent event.",
     "long_description": "The conjunction fallacy is an inference that a conjunction of two events is more probable than one of the events alone. It is a formal fallacy that is a special case of the broader category of extension neglect. The most famous example is the 'Linda problem,' where people are asked to judge whether it is more likely that Linda is a bank teller or a bank teller and a feminist. Most people choose the latter, even though it is logically impossible for a conjunction of two events to be more probable than one of the events alone.",
     "example_application": "Believing that a man is more likely to be a professor and a politician than just a professor.",
+    "real_world_examples": [
+      "In a political poll, people might be asked if they are more concerned about 'the economy' or 'the economy and the threat of terrorism.' Many people will choose the latter, even though it is a more specific and therefore less probable event.",
+      "A news report might describe a suspect as 'a man with a criminal record who is also a drug addict.' This might lead people to believe that the suspect is more likely to be guilty, even though the two attributes together are less probable than either one alone."
+    ],
     "tags": ["probability", "logic", "judgment"]
   },
   {
@@ -74,6 +114,10 @@
     "short_description": "Ignoring general prevalence when evaluating specific cases.",
     "long_description": "The base rate fallacy, also called base rate neglect or base rate bias, is a formal fallacy. If presented with related base rate information (i.e., general statistical information) and specific information (i.e., information pertaining only to a certain case), the mind tends to ignore the former and focus on the latter. For example, if you are told that a certain test for a disease is 99% accurate, and you test positive, you might think you have a 99% chance of having the disease. However, if the disease is very rare, the probability that you actually have the disease is much lower.",
     "example_application": "Assuming a person is a librarian because they are quiet and shy, even though there are far more salespeople than librarians in the population.",
+    "real_world_examples": [
+      "After a terrorist attack, people might overestimate the risk of terrorism, even though the statistical probability of being a victim of terrorism is very low.",
+      "A doctor might diagnose a patient with a rare disease based on a few symptoms, even though the disease is extremely rare in the general population."
+    ],
     "tags": ["probability", "statistics", "judgment"]
   },
   {
@@ -81,6 +125,10 @@
     "short_description": "Making inferences about an individual based on aggregate data for a group.",
     "long_description": "The ecological fallacy is a formal fallacy in the interpretation of statistical data that occurs when inferences about the nature of individuals are deduced from inferences about the group to which those individuals belong. For example, if a study shows that countries with high average incomes have high rates of heart disease, it would be an ecological fallacy to conclude that rich people are more likely to have heart disease. It is possible that the association is due to other factors, such as the fact that people in rich countries are more likely to eat processed foods.",
     "example_application": "Assuming that an individual from a wealthy country is wealthy.",
+    "real_world_examples": [
+      "A study finds that states with a higher proportion of immigrants have lower crime rates. It would be an ecological fallacy to conclude from this that immigrants are less likely to commit crimes. It is possible that immigrants tend to move to states that are already experiencing economic growth, which is also associated with lower crime rates.",
+      "A company might find that its sales are higher in cities with a younger population. It would be an ecological fallacy to conclude that young people are more likely to buy their product. It is possible that other factors, such as the presence of universities or a more vibrant nightlife, are responsible for the higher sales."
+    ],
     "tags": ["statistics", "correlation", "inference"]
   }
 ]


### PR DESCRIPTION
This commit introduces a new 'real-world examples' section to the Statistical Fallacy Spotter application.

- Adds a `real_world_examples` array to each fallacy in the `statistical-fallacies.json` data file, containing examples from news and social media.
- Updates `index.html` to include a dedicated area within the modal for displaying these examples.
- Modifies `script.js` to fetch and dynamically populate the real-world examples in the modal for each fallacy.