### PR TITLE
fix: Fix bug in Probability Simulator app

### DIFF
--- a/apps/probability-simulator/script.js
+++ b/apps/probability-simulator/script.js
@@ -44,9 +44,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function startSimulation() {
-        if (simulationRunning) {
-            return;
-        }
+        stopSimulation();
         simulationRunning = true;
         const selectedDistribution = distributionSelect.value;
         if (selectedDistribution === 'coin') {


### PR DESCRIPTION
This commit fixes a bug in the Probability Simulator app where the second simulation would not run after the first one was stopped.

The `startSimulation` function now calls `stopSimulation` at the beginning to ensure that any running simulation is stopped before a new one is started.