### PR TITLE
fix: Correct syntax error in hub.html

### DIFF
--- a/hub.html
+++ b/hub.html
@@ -51,7 +51,7 @@
             { name: "Probability Simulator", href: "apps/probability-simulator/index.html", description: "An interactive tool to visualize and understand probability distributions.", topic: "Tools & Calculators" },
             { name: "Prompt Generator", href: "PromptGeneratorV1.html", description: "An expert prompt crafter to create detailed and effective prompts for AI.", topic: "AI & Prompting" },
             { name: "Prompt Templates", href: "PromptTemplates.html", description: "A library of prompt templates for various tasks.", topic: "AI & Prompting" },
-            { name: "Prompting Primer", href: "PromptingPrimer.html", a detailed guide on prompt engineering.", topic: "AI & Prompting" },
+            { name: "Prompting Primer", href: "PromptingPrimer.html", description: "A detailed guide on prompt engineering.", topic: "AI & Prompting" },
             { name: "Report on AI Agents", href: "ReportonAIAgents.html", description: "An interactive report on the rise of AI agents and their impact on the enterprise.", topic: "AI & Prompting" },
             { name: "Spanish Primer", href: "SpanishPrimer.html", description: "A primer for learning Spanish verbs, including conjugation tables and a quiz.", topic: "Learning & Primers" },
             { name: "Talk Smarter", href: "TalkSmarter.html", description: "An interactive primer on spontaneous speaking.", topic: "Learning & Primers" },


### PR DESCRIPTION
This commit fixes a bug where the hub page would appear blank. A JavaScript syntax error in the `utilities` data array was preventing the script from parsing and executing, which meant the utility tiles were never rendered.

The missing `description` key has been added to the "Prompting Primer" object to resolve the error.