### PR TITLE
feat: Add interactive quiz to Statistical Fallacy Spotter

### DIFF
--- a/apps/statistical-fallacy-spotter/index.html
+++ b/apps/statistical-fallacy-spotter/index.html
@@ -11,6 +11,7 @@
     <header>
         <h1>Statistical Fallacy Spotter</h1>
         <p>An interactive tool to learn about statistical fallacies and improve critical thinking.</p>
+        <button id="start-quiz-btn" class="start-quiz-btn">Start Quiz</button>
     </header>
 
     <main>
@@ -39,6 +40,23 @@
         </div>
     </div>
 
+    <div id="quiz-modal" class="modal">
+        <div class="modal-content">
+            <span class="close-quiz-btn">&times;</span>
+            <div id="quiz-container">
+                <h2 id="quiz-question"></h2>
+                <div id="quiz-options" class="quiz-options"></div>
+                <button id="quiz-next-btn">Next</button>
+                <div id="quiz-feedback"></div>
+            </div>
+            <div id="quiz-results" class="hidden">
+                <h2>Quiz Complete!</h2>
+                <p>Your final score is: <span id="quiz-score"></span></p>
+                <button id="quiz-restart-btn">Restart Quiz</button>
+            </div>
+        </div>
+    </div>
+
     <footer>
         <a href="../../hub.html">Back to Hub</a>
     </footer>
@@ -49,10 +67,11 @@
         <div class="about-content">
             <span class="close-about-btn">&times;</span>
             <h2>About</h2>
-            <p>Version: 1.1.0</p>
-            <p>Last Updated: 2025-08-05</p>
+            <p>Version: 1.2.0</p>
+            <p>Last Updated: 2025-08-24</p>
             <h3>Release Notes:</h3>
             <ul>
+                <li>🚀 Added interactive quiz feature</li>
                 <li>✨ Added 'Real-World Examples' section</li>
                 <li>🆕 Initial release</li>
             </ul>

--- a/apps/statistical-fallacy-spotter/script.js
+++ b/apps/statistical-fallacy-spotter/script.js
@@ -115,4 +115,125 @@ document.addEventListener('DOMContentLoaded', () => {
             aboutPanel.style.display = 'none';
         }
     });
+
+    // Quiz Logic
+    const startQuizBtn = document.getElementById('start-quiz-btn');
+    const quizModal = document.getElementById('quiz-modal');
+    const closeQuizBtn = document.querySelector('.close-quiz-btn');
+    const quizQuestion = document.getElementById('quiz-question');
+    const quizOptions = document.getElementById('quiz-options');
+    const quizNextBtn = document.getElementById('quiz-next-btn');
+    const quizFeedback = document.getElementById('quiz-feedback');
+    const quizResults = document.getElementById('quiz-results');
+    const quizContainer = document.getElementById('quiz-container');
+    const quizScore = document.getElementById('quiz-score');
+    const quizRestartBtn = document.getElementById('quiz-restart-btn');
+
+    let quizFallacies = [];
+    let currentQuestionIndex = 0;
+    let score = 0;
+    let selectedAnswer = null;
+
+    function startQuiz() {
+        quizFallacies = [...fallacies].sort(() => 0.5 - Math.random());
+        currentQuestionIndex = 0;
+        score = 0;
+        quizContainer.classList.remove('hidden');
+        quizResults.classList.add('hidden');
+        showQuestion();
+        quizModal.style.display = 'block';
+    }
+
+    function showQuestion() {
+        selectedAnswer = null;
+        quizFeedback.textContent = '';
+        quizNextBtn.disabled = true;
+        quizNextBtn.textContent = 'Next';
+
+        const currentFallacy = quizFallacies[currentQuestionIndex];
+        quizQuestion.textContent = currentFallacy.short_description;
+
+        const options = getQuizOptions(currentFallacy);
+        quizOptions.innerHTML = '';
+        options.forEach(option => {
+            const button = document.createElement('button');
+            button.textContent = option.name;
+            button.dataset.fallacyName = option.name;
+            button.addEventListener('click', () => selectAnswer(button, currentFallacy));
+            quizOptions.appendChild(button);
+        });
+    }
+
+    function getQuizOptions(correctFallacy) {
+        const incorrectFallacies = fallacies
+            .filter(f => f.name !== correctFallacy.name)
+            .sort(() => 0.5 - Math.random())
+            .slice(0, 3);
+
+        const options = [correctFallacy, ...incorrectFallacies];
+        return options.sort(() => 0.5 - Math.random());
+    }
+
+    function selectAnswer(selectedButton, correctFallacy) {
+        if (selectedAnswer) return; // Prevent changing answer
+
+        selectedAnswer = selectedButton;
+        const isCorrect = selectedButton.dataset.fallacyName === correctFallacy.name;
+
+        if (isCorrect) {
+            score++;
+            quizFeedback.textContent = "Correct!";
+            quizFeedback.style.color = '#15803d'; // green-700
+        } else {
+            quizFeedback.textContent = `Incorrect. The correct answer is ${correctFallacy.name}.`;
+            quizFeedback.style.color = '#b91c1c'; // red-700
+        }
+
+        Array.from(quizOptions.children).forEach(button => {
+            button.disabled = true;
+            if (button.dataset.fallacyName === correctFallacy.name) {
+                button.classList.add('correct');
+            } else if (button === selectedButton) {
+                button.classList.add('incorrect');
+            }
+        });
+
+        quizNextBtn.disabled = false;
+        if (currentQuestionIndex === quizFallacies.length - 1) {
+            quizNextBtn.textContent = 'Show Results';
+        }
+    }
+
+    function nextQuestion() {
+        currentQuestionIndex++;
+        if (currentQuestionIndex < quizFallacies.length) {
+            resetOptionButtons();
+            showQuestion();
+        } else {
+            showResults();
+        }
+    }
+
+    function resetOptionButtons() {
+        Array.from(quizOptions.children).forEach(button => {
+            button.disabled = false;
+            button.classList.remove('correct', 'incorrect', 'selected');
+        });
+    }
+
+    function showResults() {
+        quizContainer.classList.add('hidden');
+        quizResults.classList.remove('hidden');
+        quizScore.textContent = `${score} / ${quizFallacies.length}`;
+    }
+
+    function closeQuiz() {
+        quizModal.style.display = 'none';
+        resetOptionButtons();
+    }
+
+    startQuizBtn.addEventListener('click', startQuiz);
+    quizNextBtn.addEventListener('click', nextQuestion);
+    quizRestartBtn.addEventListener('click', startQuiz);
+    closeQuizBtn.addEventListener('click', closeQuiz);
 });

--- a/apps/statistical-fallacy-spotter/styles.css
+++ b/apps/statistical-fallacy-spotter/styles.css
@@ -115,6 +115,135 @@ main {
     cursor: pointer;
 }
 
+/* Quiz Styles */
+.start-quiz-btn {
+    background-color: #facc15; /* yellow-400 */
+    color: #422006; /* yellow-900 */
+    border: none;
+    padding: 0.75rem 1.5rem;
+    font-size: 1rem;
+    font-weight: 600;
+    border-radius: 0.375rem;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+    margin-top: 1rem;
+}
+
+.start-quiz-btn:hover {
+    background-color: #eab308; /* yellow-500 */
+}
+
+.close-quiz-btn {
+    color: #aaa;
+    float: right;
+    font-size: 28px;
+    font-weight: bold;
+    position: absolute;
+    top: 1rem;
+    right: 1.5rem;
+    cursor: pointer;
+}
+
+#quiz-question {
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin-bottom: 1.5rem;
+    color: #1f2937;
+}
+
+.quiz-options {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    margin-bottom: 1.5rem;
+}
+
+.quiz-options button {
+    background-color: #f9fafb; /* gray-50 */
+    border: 1px solid #d1d5db; /* gray-300 */
+    padding: 0.75rem;
+    font-size: 1rem;
+    border-radius: 0.375rem;
+    cursor: pointer;
+    text-align: left;
+    transition: background-color 0.2s, border-color 0.2s;
+}
+
+.quiz-options button:hover {
+    background-color: #f3f4f6; /* gray-100 */
+    border-color: #9ca3af; /* gray-400 */
+}
+
+.quiz-options button.selected {
+    background-color: #dbeafe; /* blue-200 */
+    border-color: #60a5fa; /* blue-400 */
+}
+
+.quiz-options button.correct {
+    background-color: #dcfce7; /* green-200 */
+    border-color: #4ade80; /* green-400 */
+}
+
+.quiz-options button.incorrect {
+    background-color: #fee2e2; /* red-200 */
+    border-color: #f87171; /* red-400 */
+}
+
+#quiz-next-btn {
+    background-color: #16a34a;
+    color: white;
+    border: none;
+    padding: 0.75rem 1.5rem;
+    font-size: 1rem;
+    font-weight: 600;
+    border-radius: 0.375rem;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+    display: block;
+    margin-left: auto;
+}
+
+#quiz-next-btn:disabled {
+    background-color: #9ca3af; /* gray-400 */
+    cursor: not-allowed;
+}
+
+#quiz-feedback {
+    margin-top: 1rem;
+    font-size: 1.125rem;
+    font-weight: 600;
+}
+
+#quiz-results {
+    text-align: center;
+}
+
+#quiz-results h2 {
+    font-size: 2rem;
+    color: #15803d;
+}
+
+#quiz-results p {
+    font-size: 1.25rem;
+}
+
+#quiz-restart-btn {
+    background-color: #16a34a;
+    color: white;
+    border: none;
+    padding: 0.75rem 1.5rem;
+    font-size: 1rem;
+    font-weight: 600;
+    border-radius: 0.375rem;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+    margin-top: 1rem;
+}
+
+.hidden {
+    display: none;
+}
+
 #modal-title {
     margin-top: 0;
     color: #15803d;


### PR DESCRIPTION
This commit introduces a new interactive quiz feature to the Statistical Fallacy Spotter application.

The key changes include:
- A 'Start Quiz' button on the main page.
- A quiz modal with multiple-choice questions generated from the existing fallacy data.
- Functionality to track user score and provide immediate feedback on answers.
- A results screen at the end of the quiz with the final score and an option to restart.
- Updated 'About' panel with the new version number and release notes.
- New CSS styles to ensure the quiz is visually consistent with the application.